### PR TITLE
bugfix for `grunt s`

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "babel": "^5.8.3",
     "babel-core": "^5.8.3",
     "babel-loader": "^5.3.2",
+    "babel-runtime": "^5.8.12",
     "bower": "^1.4.1",
     "css-loader": "^0.15.5",
     "grunt": "^0.4.5",


### PR DESCRIPTION
1. add babel-runtime in package.json
2. a change in fixtures directory, but cannot pushed...
