### PR TITLE
Grunt 的 contentBase  可以通过 `--content-base` 参数来指定

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,6 +2,9 @@ var webpackConfig = require('./webpack.config.js')
 
 module.exports = function(grunt) {
   require('load-grunt-tasks')(grunt)
+
+  var contentBase = grunt.option('content-base') || './fixtures/ancient-egypt'
+
   grunt.initConfig({
     webpack: {
       options: webpackConfig
@@ -10,7 +13,7 @@ module.exports = function(grunt) {
   , 'webpack-dev-server': {
       options: {
         webpack: webpackConfig
-      , contentBase: './fixtures/ancient-egypt/'
+      , contentBase: contentBase
       , publicPath: '/'
       , port: 8000
       , hot: true


### PR DESCRIPTION
example:

``` bash

grunt s --content-base=/Users/yangqing/temp/crawled_from_douban

```
