### PR TITLE
komic 项目添加 `komic-web-dev [文件夹名字]` 可以在调试文件夹

### DIFF
--- a/bin/komic-web-dev
+++ b/bin/komic-web-dev
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+var path = require("path")
+  , spawn = require('child_process').spawn
+  , fs = require('fs')
+
+var args = process.argv.slice(2)
+  , gruntfile = path.join(__dirname, '../Gruntfile.js')
+  , contentBase = path.join(process.cwd(), args[0])
+
+if (!fs.lstatSync(contentBase).isDirectory()) {
+  throw new Error(contentBase + ' isn\'t directiory')
+  return
+}
+
+var child = spawn('grunt', [
+    's'
+  , '--gruntfile', gruntfile
+  , '--content-base', contentBase
+  ])
+
+;['stdout', 'stdin', 'stderr'].forEach(function(methodName) {
+  child[methodName].on('data', function(data) {
+    process[methodName].write(data)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "postinstall": "$(npm bin)/bower install"
   },
+  "bin": {
+    "komic-web-dev": "./bin/komic-web-dev"
+  },
   "author": "",
   "license": "ISC",
   "devDependencies": {


### PR DESCRIPTION
Example
1. `komic mock --name mock` 生成名字为 mock 的数据文件夹
1. `npm link` 安装 `komic-web-dev`
1. 切换到带有 mock 的所在目录
1. 运行 `komic-web-dev mock` 开始使用 grunt 调用当前目录为 contentBase
