### PR TITLE
添加自动分页功能

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -34,14 +34,14 @@ class AppModel extends Model {
   }
 
   createCanvasModel() {
-    var bookModel = this.getModel('book')
-      , canvasModel = new CanvasModel(bookModel.getCanvasModelInfo())
+    var canvasModel = new CanvasModel()
     this.setModel('canvas', canvasModel)
     return canvasModel
   }
 
   createBookModel() {
-    this.setModel('book', new BookModel())
+    this.setModel('book', new BookModel({
+      canvas: this.getModel('canvas') }))
     return this.getModel('book')
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -12,15 +12,15 @@ $(document).on('click', 'a[href="#"]', (e) => {
   e.preventDefault()
 })
 
-var bookModel = app.createModel('book')
+var canvasModel = app.createModel('canvas')
+  , bookModel = app.createModel('book')
   , appViewWrapper = $('<div>', {'class': 'react-app-wrapper'})
 
 $('body').prepend(appViewWrapper)
 
-bookModel.fetch({ url: './content.json' })
+bookModel.fetchContent({ url: './content.json' })
   .done(() => {
     app.trigger('fetched:book')
-    app.createModel('canvas')
     var router = Router.create({
       routes: routes
     , location: Router.HashLocation

--- a/src/manager/loader.js
+++ b/src/manager/loader.js
@@ -5,44 +5,13 @@ import Store from './store'
 import request from 'mods/request'
 import _ from 'mods/utils'
 
-var Model = Backbone.Model.extend({
-  getImage: () => {
-    return app.getModel('book').getCurrentImage()
-  }
-
-, getCurrentPage: () => {
-    return app.getModel('book').get('currentPage')
-  }
-
-, getTotalPage: () => {
-    return app.getModel('book').get('totalPage')
-  }
-
-, getImageUri: () => {
-    return app.getModel('book').getCurrentImageUri()
-  }
-
-, getCurrentImageUri() {
-    let page = this.getCurrentPage()
-    return this.getImageUri(page)
-  }
-
-, getBookTitle: () => {
-    return app.getModel('book').getTitle()
-  }
-
-, getUUID: () => {
-    return app.getModel('book').getUUID()
-  }
-})
-
 class Loader {
   constructor (options) {
-    this.model = new Model()
     this.THRESHOLD = 5
     this.xhr = undefined
     app.on('fetched:book', () => {
-      let uuid = this.model.getUUID()
+      let book = app.getModel('book')
+        , uuid = book.getUUID()
         , version
         , versionTable = new Map(this.getFromLocalStorage())
 
@@ -62,7 +31,7 @@ class Loader {
       let config = {
         'name': 'komic'
       , 'version': version
-      , 'storeName': this.model.getBookTitle()+uuid
+      , 'storeName': book.getTitle()+uuid
       }
       this.store = new Store(config)
     }, this)
@@ -79,13 +48,14 @@ class Loader {
 
   preloadImages() {
     this.stopLoading()
-    let model = this.model
-      , total = model.getTotalPage()
-      , currentPage = model.getCurrentPage()
+    let book = app.getModel('book')
+      , total = book.getBookTotalPage()
+      , currentPage = book.get('currentPage')
       , start = currentPage + 1
       , end = start + this.THRESHOLD > total ? total + 1 : start + this.THRESHOLD
       , pages = _.range(start, end)
-      , urls = pages.map((val) => { return model.getImageUri(val) })
+      , urls = _.uniq(
+        pages.map((page) => { return book.getImageUri({ page: page }) }))
       , cachedUrls = []
       , self = this
 
@@ -118,9 +88,9 @@ class Loader {
 
   loadCurrentImage({ requestEvents }) {
     this.stopLoading()
-    let model = this.model
-      , page = model.getCurrentPage()
-      , src = model.getImageUri(page)
+    let book = app.getModel('book')
+      , page = book.get('currentPage')
+      , src = book.getImageUri({ page: page })
       , noop = function() {}
       , self = this
 
@@ -149,7 +119,7 @@ class Loader {
   }
 
   storeCurrentImage(val) {
-    let key = this.model.getCurrentImageUri()
+    let key = app.getModel('book').getCurrentImageUri()
       , self = this
 
     return this.hasLoaded(key).catch(() => {
@@ -164,13 +134,15 @@ class Loader {
   }
 
   pickCachedImage(page) {
-    let url = this.model.getImageUri(page)
+    let book = app.getModel('book')
+      , url = book.getImageUri({ page: page })
 
     return this.store.getItem(url)
   }
 
   hasLoaded(key) {
-    let url = key||this.model.getCurrentImageUri()
+    let book = app.getModel('book')
+      , url = key || book.getCurrentImageUri()
     return this.store.getItem(url)
   }
 }

--- a/src/manager/loader.js
+++ b/src/manager/loader.js
@@ -6,20 +6,20 @@ import request from 'mods/request'
 import _ from 'mods/utils'
 
 var Model = Backbone.Model.extend({
-  getImage: (page) => {
-    return app.getModel('book').getCurrentImage(page)
+  getImage: () => {
+    return app.getModel('book').getCurrentImage()
   }
 
 , getCurrentPage: () => {
-    return app.getModel('canvas').get('currentPage')
+    return app.getModel('book').get('currentPage')
   }
 
 , getTotalPage: () => {
-    return app.getModel('canvas').get('totalPage')
+    return app.getModel('book').get('totalPage')
   }
 
-, getImageUri: (page) => {
-    return app.getModel('book').getCurrentImageUri(page)
+, getImageUri: () => {
+    return app.getModel('book').getCurrentImageUri()
   }
 
 , getCurrentImageUri() {

--- a/src/manager/loader.js
+++ b/src/manager/loader.js
@@ -125,16 +125,16 @@ class Loader {
       , self = this
 
     return this.hasLoaded(src).then(() => {
-      return Promise.resolve()
+      return this.pickCachedImage(page)
     }, () => {
       return new Promise((resolve, reject) => {
         self.store.getItem(src).then((imageBlob) => {
-          resolve()
+          resolve(imageBlob)
         }, () => {
           self.fetch({ url: src, events: requestEvents })
             .then((imageBlob) => {
                self.storeCurrentImage(imageBlob).then(() => {
-                 resolve()
+                 resolve(imageBlob)
                }, noop)
             })
         })
@@ -166,11 +166,7 @@ class Loader {
   pickCachedImage(page) {
     let url = this.model.getImageUri(page)
 
-    return (
-      this.store.getItem(url).then((cached) => {
-        return window.URL.createObjectURL(cached)
-      })
-    )
+    return this.store.getItem(url)
   }
 
   hasLoaded(key) {

--- a/src/models/book.js
+++ b/src/models/book.js
@@ -2,12 +2,12 @@ import { Model } from 'backbone'
 import _ from 'mods/utils'
 import browser from 'mods/browser'
 
-const FIRST_PAGE = 0
-export default class extends Model {
+const FIRST_PAGE_INDEX = 0
+class Content extends Model {
 
   @_.Memoize()
   getImageType() {
-    var data = this.get('images')[FIRST_PAGE]
+    var data = this.get('images')[FIRST_PAGE_INDEX]
       , src = data.web && data.web.src
       , type = src['default']
 
@@ -18,49 +18,177 @@ export default class extends Model {
     return type
   }
 
-  getImage(index) {
-    var data = this.get('images')[index]
-      , web = data.web
-      , type = this.getImageType()
+  decorateImage(image, index) {
+    var web = image.web
+      , {width, height} = _.pick(web, 'width', 'height')
 
     return {
-      ..._.pick(web, 'width', 'height')
-    , src: web.src[type]
+        index: index
+      , src: web.src[this.getImageType()]
+      , splited: false
+      , width: width
+      , height: height
+      , naturalWidth: width
+      , naturalHeight: height
     }
   }
 
-  getImages(){
-    return this.get('images').map((image, index) => { return this.getImage(index) })
+  @_.Memoize()
+  unsplitedImages() {
+    var images = this.get('images')
+    return images.map(::this.decorateImage)
+  }
+
+  @_.Memoize()
+  splitedImages() {
+    var images = this.get('images')
+
+    if (_.findIndex(images, (image) => { return image.width > image.height }) === -1) {
+      return this.unsplitedImages()
+    }
+
+    var maxWidthImage = _.max(images, (image) => { return image.width })
+      , beSplitedBreakpoint = maxWidthImage.width * 0.75
+      , splitedImages = []
+
+    images.forEach((image, index) => {
+      image = this.decorateImage(image, index)
+      if (image.width > beSplitedBreakpoint) {
+        var halfWidth = image.width / 2
+          , halfWidthImage = {
+              ...image
+            , index: index
+            , splited: true
+            , width: halfWidth
+            }
+
+        return splitedImages.push(...[
+          { ...halfWidthImage, positionX: 0, splitedIndex: 0 }
+        , { ...halfWidthImage, positionX: halfWidth, splitedIndex: 1 }
+        ])
+      }
+
+      splitedImages.push({ ...image, splited: false, index: index })
+    })
+
+    return splitedImages
+  }
+}
+
+export default class extends Model {
+  initialize({ canvas }) {
+    this.canvas = canvas
+    this.content = new Content()
+  }
+
+  fetchContent(...args) {
+    return this.content.fetch(...args).done(this::() => {
+      this.set({ totalPage: this.getBookTotalPage() })
+    })
+  }
+
+  defaults() {
+    return {
+      totalPage: 0
+    , currentPage: 0
+    , splitedIndex: 0
+    }
+  }
+
+  setCurrentPage({ page, splitedIndex }) {
+    var currentPage = +page
+      , totalPage = this.get('totalPage')
+
+    if (currentPage > totalPage) {
+      currentPage = totalPage
+    }
+
+    if (currentPage < 1) {
+      currentPage = 1
+    }
+
+    this.set('currentPage', currentPage)
+    this.set('splitedIndex', splitedIndex)
+    return this
+  }
+
+  turnPage({ direction }) {
+    var images = this.getImages()
+      , currentImage = this.getCurrentImage()
+      , currentIndex = _.findIndex(images, (image) => {
+          return (image.index === currentImage.index
+            && (!currentImage.splited
+            || image.splitedIndex === currentImage.splitedIndex))
+        })
+      , silbingImageIndex = currentIndex + (direction === 'prevPage' ? -1 : 1)
+      , silbingImage = images[_.clamp(silbingImageIndex, [0, images.length - 1])]
+
+    this.setCurrentPage({
+        page: silbingImage.index + 1
+      , splitedIndex: silbingImage.splitedIndex
+      })
+  }
+
+  currentIsLastPage() {
+    var currentImage = this.getCurrentImage()
+    return (this.get('currentPage') === this.get('totalPage')
+      && (!currentImage.splited || currentImage.splitedIndex === 1))
+  }
+
+  currentIsFirstPage() {
+    var currentImage = this.getCurrentImage()
+    return (this.get('currentPage') === 1
+      && (!currentImage.splited || currentImage.splitedIndex === 0))
+  }
+
+  getImage({ page, index, splitedIndex }) {
+    var images = this.getImages()
+    if (!_.isUndefined(page)) {
+      index = page - 1
+    }
+
+    return _.find(images, (image) => {
+      return (image.index === index
+        && ( !image.splited
+        || image.splitedIndex === splitedIndex )
+      )
+    })
+  }
+
+  getImages() {
+    var content = this.content
+    return (this.canvas.get('autoSplit')
+      ? content.splitedImages()
+      : content.unsplitedImages()
+      )
   }
 
   getBookCoverSize() {
-    var cover = this.getImage(FIRST_PAGE)
+    var cover = this.getImage({ index: FIRST_PAGE_INDEX })
     return {
       width: Math.ceil(cover.width / cover.height * 220)
     , height: 220
     }
   }
 
-  getCanvasModelInfo() {
-    return {
-      totalPage: this.getImages().length
-    }
+  getBookTotalPage() {
+    return _.last(this.getImages()).index + 1
   }
 
   getBookCoverImg() {
     return {
-      ...this.getImage(FIRST_PAGE)
+      ...this.getImage({ index: FIRST_PAGE_INDEX })
     , ...this.getBookCoverSize()
     }
   }
 
-  getCurrentImageUri(page) {
-    var { src } = this.getCurrentImage(page)
-    return src
+  getCurrentImageUri() {
+    var image = this.getCurrentImage()
+    return image && image.src
   }
 
   getNaturalAverageDiagonal() {
-    var images = this.getImages()
+    var images = this.content.get('images')
       , number = images.length
       , sum = _.reduce(images, (memo, image) => {
           var diagonal = _.rectangleDiagonal(image.width, image.height)
@@ -70,21 +198,37 @@ export default class extends Model {
     return sum / number
   }
 
-  getCurrentImage(page) {
-    return this.getImage(page - 1)
+  getCurrentImage() {
+    var current = this.get('currentPage')
+      , splitedIndex = this.get('splitedIndex')
+    return this.getImage({ page: current, splitedIndex: splitedIndex })
   }
 
   getThumbnails() {
-    var rootSrc = this.get('thumbnails').path
-      , thumbHeight = this.get('thumbnails').height
+    var rootSrc = this.content.get('thumbnails').path
+      , thumbHeight = this.content.get('thumbnails').height
+
     return (
       this.getImages().map(function (image, index) {
+        var ratio = thumbHeight / image.height
+          , width = Math.ceil(image.naturalWidth * ratio)
+          , height = thumbHeight
+          , viewBoxWidth = Math.ceil(image.width * ratio)
+          , viewBoxHeight = height
+          , positionX = image.positionX ? Math.ceil(image.positionX * ratio) : 0
+
         return {
-          src: `${rootSrc}#${index}`
-        , page: `${index+1}`
-        , size: {
-            width: Math.ceil(image.width * thumbHeight / image.height)
-          , height: thumbHeight
+          src: `${rootSrc}#${image.index}`
+        , page: `${image.index + 1}`
+        , splitedIndex: image.splitedIndex
+        , positionX: positionX
+        , viewBoxSize: {
+            width: viewBoxWidth
+          , height: viewBoxHeight
+          }
+        , useElementSize: {
+            width: width
+          , height: height
           }
         }
       })
@@ -92,10 +236,10 @@ export default class extends Model {
   }
 
   getTitle() {
-    return this.get('name')
+    return this.content.get('name')
   }
 
   getUUID() {
-    return this.get('content_json_uuid')
+    return this.content.get('content_json_uuid')
   }
 }

--- a/src/models/book.js
+++ b/src/models/book.js
@@ -193,7 +193,7 @@ export default class extends Model {
   }
 
   getNaturalAverageDiagonal() {
-    var images = this.content.get('images')
+    var images = this.getImages()
       , number = images.length
       , sum = _.reduce(images, (memo, image) => {
           var diagonal = _.rectangleDiagonal(image.width, image.height)

--- a/src/models/book.js
+++ b/src/models/book.js
@@ -141,7 +141,7 @@ export default class extends Model {
       && (!currentImage.splited || currentImage.splitedIndex === 0))
   }
 
-  getImage({ page, index, splitedIndex }) {
+  getImage({ page, index, splitedIndex = 0 }) {
     var images = this.getImages()
     if (!_.isUndefined(page)) {
       index = page - 1
@@ -153,6 +153,11 @@ export default class extends Model {
         || image.splitedIndex === splitedIndex )
       )
     })
+  }
+
+  getImageUri(...args) {
+    var image = this.getImage(...args)
+    return image.src
   }
 
   getImages() {

--- a/src/models/book.js
+++ b/src/models/book.js
@@ -141,11 +141,9 @@ export default class extends Model {
       && (!currentImage.splited || currentImage.splitedIndex === 0))
   }
 
-  getImage({ page, index, splitedIndex = 0 }) {
+  getImage({ page, splitedIndex = 0 }) {
     var images = this.getImages()
-    if (!_.isUndefined(page)) {
-      index = page - 1
-    }
+      , index = page - 1
 
     return _.find(images, (image) => {
       return (image.index === index

--- a/src/models/book.js
+++ b/src/models/book.js
@@ -18,7 +18,7 @@ class Content extends Model {
     return type
   }
 
-  decorateImage(image, index) {
+  wrapImage(image, index) {
     var web = image.web
       , {width, height} = _.pick(web, 'width', 'height')
 
@@ -36,7 +36,7 @@ class Content extends Model {
   @_.Memoize()
   unsplitedImages() {
     var images = this.get('images')
-    return images.map(::this.decorateImage)
+    return images.map(::this.wrapImage)
   }
 
   @_.Memoize()
@@ -52,7 +52,7 @@ class Content extends Model {
       , splitedImages = []
 
     images.forEach((image, index) => {
-      image = this.decorateImage(image, index)
+      image = this.wrapImage(image, index)
       if (image.width > beSplitedBreakpoint) {
         var halfWidth = image.width / 2
           , halfWidthImage = {

--- a/src/models/canvas.js
+++ b/src/models/canvas.js
@@ -1,12 +1,10 @@
 import { Model } from 'backbone'
 
+
 export default class extends Model {
 
   constructor(options) {
     super(options)
-    if (options.totalPage && options.totalPage > 0) {
-      this.set('currentPage', 1)
-    }
     this.on('change', this.saveToLocalStorage)
   }
 
@@ -22,41 +20,11 @@ export default class extends Model {
   defaults() {
     return (
       this.getFromLocalStorage() || {
-        totalPage: 0
-      , currentPage: 0
-      , turnpageMethod: 'CLICK'
+        turnpageMethod: 'CLICK'
       , scalingMethod: 'AUTO'
       , mousePositionDragImage: false
+      , autoSplit: false
       })
-  }
-
-  setCurrentPage(currentPage) {
-    currentPage = +currentPage
-    var totalPage = this.get('totalPage')
-    if (currentPage > totalPage) {
-      currentPage = totalPage
-    }
-
-    if (currentPage < 1) {
-      currentPage = 1
-    }
-
-    this.set('currentPage', currentPage)
-    return this
-  }
-
-  turnPage({ direction }) {
-    var currentPage = this.get('currentPage')
-    this.setCurrentPage(currentPage
-      + (direction === 'prevPage' ? -1 : 1))
-  }
-
-  currentIsLastPage() {
-    return this.get('currentPage') === this.get('totalPage')
-  }
-
-  currentIsFirstPage() {
-    return this.get('currentPage') === 1
   }
 
 }

--- a/src/views/book_intro.js
+++ b/src/views/book_intro.js
@@ -19,7 +19,7 @@ class BookCover extends React.Component {
           <li>
             <VertialAlignMiddle>
               <div style={ Object.assign(model.getBookCoverSize(), {textAlign: 'center'}) }>
-                <Link to="reader" params={{page: "0"}} className="btn btn-read">阅 读</Link>
+                <Link to="reader" params={{page: "1"}} className="btn btn-read">阅 读</Link>
               </div>
             </VertialAlignMiddle>
           </li>
@@ -42,7 +42,7 @@ class BookCover extends React.Component {
 
 class BookIntroDetail extends React.Component {
   render() {
-    var model = this.props.model
+    var model = this.props.model.content
     return (
       <div className="book-intro-detail">
         <h1>{ model.get('name') }</h1>

--- a/src/views/reader/canvas/image.js
+++ b/src/views/reader/canvas/image.js
@@ -198,7 +198,6 @@ export default class extends React.Component {
   render() {
     var book = app.getModel('book')
       , canvas = app.getModel('canvas')
-      , currentPage = app.getModel('canvas').get('currentPage')
       , { width, height } = book.getCurrentImage()
 
     return (

--- a/src/views/reader/canvas/image.js
+++ b/src/views/reader/canvas/image.js
@@ -6,8 +6,6 @@ import Backbone from 'backbone'
 import _ from 'mods/utils'
 import loader from 'manager/loader'
 
-import VerticalAlignMiddle from 'widgets/vertical_align_middle'
-
 const win = $(window)
     , MOUSE_RIGHT_BUTTON = 2
     , SCROLL_DURATION = 230
@@ -97,11 +95,7 @@ export default class extends React.Component {
     this.guid = _.uniqueId()
     this.manager = this.props.manager
     this.model = new Model({ manager: this.manager })
-    this.state = { display: true, loaded: false, url: undefined }
-  }
-
-  componentWillReceiveProps() {
-    this.state = { loaded: false}
+    this.state = { display: true }
   }
 
   componentWillMount() {
@@ -201,30 +195,16 @@ export default class extends React.Component {
     this::ContextMenuHandlers[canvas.get('turnpageMethod')](e)
   }
 
-  //XXX(kyon) how to render async data
   render() {
-    let self = this
-      , currentPage = app.getModel('canvas').get('currentPage')
-
-    if (this.state.loaded) {
-      return this.renderWithImage()
-    } else {
-      loader.pickCachedImage(currentPage).then((src) => {
-        self.setState({ loaded: true, url: src })
-      })
-      return this.renderWithLoading()
-    }
-  }
-
-  renderWithImage() {
     var book = app.getModel('book')
       , currentPage = app.getModel('canvas').get('currentPage')
-      , img = { ...book.getCurrentImage(currentPage) }
-
-    img.src = this.state.url
+      , { width, height } = book.getCurrentImage(currentPage)
 
     return (
-      <img { ...img }
+      <img
+        src={ window.URL.createObjectURL(this.props.blob) }
+        width={ width }
+        height={ height }
         key={ _.uniqueId() }
         style={{ display: this.state.display ? 'block' : 'none' }}
         ref="image"
@@ -236,18 +216,6 @@ export default class extends React.Component {
         onLoad={ ::loader.preloadImages}
         onContextMenu={ this.handleContextMenu }
         />
-    )
-  }
-
-  renderWithLoading() {
-    return (
-      <div className="canvas">
-        <VerticalAlignMiddle style={
-          { width: '100%', height: '100%', textAlign: 'center' }
-          }>
-          载入中
-        </VerticalAlignMiddle>
-      </div>
     )
   }
 }

--- a/src/views/reader/canvas/image.js
+++ b/src/views/reader/canvas/image.js
@@ -138,9 +138,9 @@ export default class extends React.Component {
   }
 
   turnPage(direction) {
-    var canvas = app.getModel('canvas')
+    var book = app.getModel('book')
 
-    canvas.trigger('turn:page', { direction })
+    book.trigger('turn:page', { direction })
   }
 
   turnPrevPage() {
@@ -197,12 +197,13 @@ export default class extends React.Component {
 
   render() {
     var book = app.getModel('book')
+      , canvas = app.getModel('canvas')
       , currentPage = app.getModel('canvas').get('currentPage')
-      , { width, height } = book.getCurrentImage(currentPage)
+      , { width, height } = book.getCurrentImage()
 
     return (
       <img
-        src={ window.URL.createObjectURL(this.props.blob) }
+        src={ this.props.src }
         width={ width }
         height={ height }
         key={ _.uniqueId() }

--- a/src/views/reader/canvas/index.js
+++ b/src/views/reader/canvas/index.js
@@ -35,7 +35,7 @@ export default class extends React.Component {
     var { READY, LOADED } = LoadingStates
       , self = this
 
-    this.state = { loadingState: READY }
+    this.state = { loadingState: READY, percent: 0 }
   }
 
   componentWillMount() {

--- a/src/views/reader/canvas/index.js
+++ b/src/views/reader/canvas/index.js
@@ -39,37 +39,42 @@ export default class extends React.Component {
   }
 
   componentWillMount() {
-    var canvas = app.getModel('canvas')
-    canvas
+    var book = app.getModel('book')
+    book
       .on('turn:page', ::this.showTurnPageTip)
       .on('turn:page', ::this.transitionToPage)
   }
 
   componentWillUnmount() {
-    var canvas = app.getModel('canvas')
-    canvas
+    var book = app.getModel('book')
+    book
       .off('turn:page', ::this.showTurnPageTip)
       .off('turn:page', ::this.transitionToPage)
   }
 
   showTurnPageTip({ direction }) {
-    var canvas = app.getModel('canvas')
+    var book = app.getModel('book')
 
     app.trigger('close:tip')
 
-    if (canvas.currentIsFirstPage() && direction === 'prevPage') {
+    if (book.currentIsFirstPage() && direction === 'prevPage') {
       app.trigger('open:tip', { text: '目前已经是第一页' })
-    } else if (canvas.currentIsLastPage() && direction === 'nextPage') {
+    } else if (book.currentIsLastPage() && direction === 'nextPage') {
       app.trigger('open:tip', { text: '目前已经是最后一页' })
     }
   }
 
   transitionToPage({ direction }) {
     var router = app.get('router')
+      , book = app.getModel('book')
       , canvas = app.getModel('canvas')
 
-    canvas.turnPage({ direction })
-    router.transitionTo('page', { page: canvas.get('currentPage') })
+    book.turnPage({ direction })
+    router.transitionTo(
+      'page'
+    , { page: book.get('currentPage') }
+    , canvas.get('autoSplit') && { splitedIndex: book.get('splitedIndex') }
+    )
   }
 
   scrollHandler(e) {
@@ -115,9 +120,35 @@ export default class extends React.Component {
         onMouseMove= { ::this.mouseMoveHandle }
         >
         <CanvasImage manager={ this.imageManger }
-          blob={ this.state.imageBlob } />
+          src={ this.state.imageSrc } />
       </div>
     )
+  }
+
+  cropImageWhenAutoSplit(imageBlob) {
+    return new Promise((resolve, reject) => {
+      var book = app.getModel('book')
+        , canvas = app.getModel('canvas')
+        , image = book.getCurrentImage()
+        , { naturalWidth, naturalHeight} = image
+        , { width, height, positionX } = image
+
+      if (!canvas.get('autoSplit') || !image.splited) {
+        return resolve(window.URL.createObjectURL(imageBlob))
+      }
+
+      var croppingCanvas = document.createElement("canvas")
+      croppingCanvas.width = width
+      croppingCanvas.height = height
+      var image = new Image()
+      image.src = window.URL.createObjectURL(imageBlob)
+      image.onerror = reject
+      image.onload = function() {
+        croppingCanvas.getContext('2d')
+          .drawImage(image, -positionX, 0, naturalWidth, naturalHeight)
+        resolve(croppingCanvas.toDataURL())
+      }
+    })
   }
 
   renderAndLoadImage() {
@@ -130,10 +161,11 @@ export default class extends React.Component {
           })
         }
       }})
-      .then((imageBlob) => {
+      .then(this.cropImageWhenAutoSplit)
+      .then((blobUriOrDataUri) => {
         this.setState({
           loadingState: LoadingStates.LOADED
-        , imageBlob: imageBlob
+        , imageSrc: blobUriOrDataUri
         })
       })
     return this.renderWithLoading()

--- a/src/views/reader/canvas/index.js
+++ b/src/views/reader/canvas/index.js
@@ -36,11 +36,6 @@ export default class extends React.Component {
       , self = this
 
     this.state = { loadingState: READY }
-    loader.hasLoaded().then(() => {
-      self.state = { loadingState: LOADED}
-    }, () =>{
-      self.state = { loadingState: READY }
-    })
   }
 
   componentWillMount() {
@@ -119,7 +114,8 @@ export default class extends React.Component {
         onWheel={ ::this.scrollHandler }
         onMouseMove= { ::this.mouseMoveHandle }
         >
-        <CanvasImage manager={ this.imageManger } />
+        <CanvasImage manager={ this.imageManger }
+          blob={ this.state.imageBlob } />
       </div>
     )
   }
@@ -134,8 +130,11 @@ export default class extends React.Component {
           })
         }
       }})
-      .then(() => {
-        this.setState({ loadingState: LoadingStates.LOADED })
+      .then((imageBlob) => {
+        this.setState({
+          loadingState: LoadingStates.LOADED
+        , imageBlob: imageBlob
+        })
       })
     return this.renderWithLoading()
   }

--- a/src/views/reader/index.js
+++ b/src/views/reader/index.js
@@ -17,16 +17,19 @@ export default class extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    var params = nextProps.params
-      , canvas = app.getModel('canvas')
-    if (params && params.page) {
-      canvas.setCurrentPage(params.page)
-    }
+    this.setCurrentPage(nextProps)
+  }
+
+
+  setCurrentPage(props) {
+    var book = app.getModel('book')
+      , page = props.params && +props.params.page
+      , splitedIndex = +props.query.splitedIndex || 0
+    book.setCurrentPage({ page: page, splitedIndex: splitedIndex })
   }
 
   componentWillMount() {
-    var canvas = app.getModel('canvas')
-    canvas.setCurrentPage(+this.props.params.page)
+    this.setCurrentPage(this.props)
     app.on('toggle:thumbview', this.toggleThumbview, this)
   }
 

--- a/src/views/reader/modals/config.js
+++ b/src/views/reader/modals/config.js
@@ -10,11 +10,13 @@ export default class extends React.Component {
       , scalingMethod = form.find('select[name=scaling-method]').val()
       , mousePositionDragImage = form.find('input[name=mouse-position-drag-image]')
           .prop("checked")
+      , autoSplit = form.find('input[name=auto-split]').prop("checked")
       , canvas = app.getModel('canvas')
 
     canvas.set('scalingMethod', scalingMethod)
     canvas.set('turnpageMethod', turnpageMethod)
     canvas.set('mousePositionDragImage', mousePositionDragImage)
+    canvas.set('autoSplit', autoSplit)
   }
 
   renderScalingMethodSelect() {
@@ -80,6 +82,24 @@ export default class extends React.Component {
     )
   }
 
+  renderAutoSplitCheckbox() {
+    var canvas = app.getModel('canvas')
+    return (
+      <div className="form-group">
+        <div className="right-block">
+          <div className="checkbox">
+            <label>
+              <input type="checkbox"
+                defaultChecked={ canvas.get('autoSplit') }
+                name="auto-split"
+                /> 自动分页
+            </label>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
   renderMousePositionDragImageCheckbox() {
     var canvas = app.getModel('canvas')
     return (
@@ -107,6 +127,7 @@ export default class extends React.Component {
           { this.renderScalingMethodSelect() }
           { this.renderTurnpageMethodSelect() }
           { this.renderMousePositionDragImageCheckbox() }
+          { this.renderAutoSplitCheckbox() }
         </form>
       </div>
     )

--- a/src/views/reader/panel.js
+++ b/src/views/reader/panel.js
@@ -13,8 +13,8 @@ export default class extends React.Component {
   }
 
   render() {
-    var canvasModel = app.getModel('canvas')
-      , currentPage = canvasModel.get('currentPage')
+    var bookModel = app.getModel('book')
+      , currentPage = bookModel.get('currentPage')
 
     return (
       <div className="aside">

--- a/src/views/reader/thumbview.js
+++ b/src/views/reader/thumbview.js
@@ -59,7 +59,7 @@ export default class extends React.Component {
     return (
       <li className={ klass } key={ index }>
         <ThumbViewLink to="page" params={{ page: page }}
-          query={ canvas.get('autoSplit') && _.pick(thumb, 'splitedIndex') }
+          query={ canvas.get('autoSplit') ? _.pick(thumb, 'splitedIndex') : null }
           ref={ isCurrent ? 'current' : null }
           className="thumb" { ...viewBoxSize }>
           <svg className="thumb" { ...viewBoxSize }

--- a/src/views/reader/thumbview.js
+++ b/src/views/reader/thumbview.js
@@ -3,6 +3,7 @@ import { Link } from 'react-router'
 import $ from 'jquery'
 
 import app from 'app'
+import _ from 'mods/utils'
 import routes from 'routes'
 import Panel from './panel'
 
@@ -11,7 +12,7 @@ class ThumbViewLink extends React.Component {
     e.preventDefault()
     app.trigger('toggle:thumbview', false)
     var router = app.get('router')
-    router.transitionTo(this.props.to, this.props.params)
+    router.transitionTo(this.props.to, this.props.params, this.props.query)
   }
 
   render() {
@@ -41,20 +42,28 @@ export default class extends React.Component {
 
   renderItem(thumb, index) {
     var canvas = app.getModel('canvas')
-      , currentPage = canvas.get('currentPage')
+      , book = app.getModel('book')
+      , currentPage = book.get('currentPage')
       , page = thumb.page
-      , size = thumb.size
-      , useTag = `<use xlink:href=${thumb.src}>`
+      , viewBoxSize = thumb.viewBoxSize
       , isCurrent = +page === +currentPage
       , klass = isCurrent ? "item current" : "item"
+      , useTag = () => {
+          var {width, height} = thumb.useElementSize
+          return (
+              `<use xlink:href=${thumb.src} width=${width}`
+            + ` height=${height} x=${-thumb.positionX} />`
+          )
+        }
 
     return (
       <li className={ klass } key={ index }>
         <ThumbViewLink to="page" params={{ page: page }}
+          query={ canvas.get('autoSplit') && _.pick(thumb, 'splitedIndex') }
           ref={ isCurrent ? 'current' : null }
-          className="thumb" { ...size }>
-          <svg className="thumb" { ...size }
-            dangerouslySetInnerHTML={{__html: useTag}}>
+          className="thumb" { ...viewBoxSize }>
+          <svg className="thumb" { ...viewBoxSize }
+            dangerouslySetInnerHTML={{__html: useTag()}}>
           </svg>
         </ThumbViewLink>
       </li>


### PR DESCRIPTION
models/book 
- 内置的 content 负责管理和存取来自 content.json 的数据。
- models/book 是一个组合了 canvas 和 content 两个 model 的对象，翻页由这个对象负责(因为翻页现在需要依赖canvas的自动分页配置，和 content 的内容)

models/canvas 
- 更纯粹的负责界面的配置

分页打开前的 url `/3` 打开后变成 `/3?splitedIndex=0`, `/3?splitedIndex=1`，这个两个页面页码的现实都是 `3` ,  （TODO：以后改成 3A, 3B 也许会更好）
### 自动分页打开后

![image](https://cloud.githubusercontent.com/assets/163671/9699288/2170517c-5410-11e5-8a97-cad04472f7c7.png)
### 自动分页未打开

![image](https://cloud.githubusercontent.com/assets/163671/9699293/32443a40-5410-11e5-9b30-c992a7e6d1f9.png)
